### PR TITLE
Improvements

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,9 @@
+{
+    "version": 2,
+    "builds": [
+        { "src": "serverless.js", "use": "@now/node" }
+    ],
+	"routes": [
+        { "src": "/.*", "dest": "/serverless.js" }
+	]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@types/node": {
-			"version": "12.12.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.5.tgz",
-			"integrity": "sha512-KEjODidV4XYUlJBF3XdjSH5FWoMCtO0utnhtdLf1AgeuZLOrRbvmU/gaRCVg7ZaQDjVf3l84egiY0mRNe5xE4A=="
-		},
 		"accepts": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -105,11 +100,6 @@
 				"type-is": "~1.6.17"
 			}
 		},
-		"boolbase": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-		},
 		"bytes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -134,19 +124,6 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-		},
-		"cheerio": {
-			"version": "1.0.0-rc.3",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
-			"integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
-			"requires": {
-				"css-select": "~1.2.0",
-				"dom-serializer": "~0.1.1",
-				"entities": "~1.1.1",
-				"htmlparser2": "^3.9.1",
-				"lodash": "^4.15.0",
-				"parse5": "^3.0.1"
-			}
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
@@ -219,22 +196,6 @@
 				"vary": "^1"
 			}
 		},
-		"css-select": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-			"requires": {
-				"boolbase": "~1.0.0",
-				"css-what": "2.1",
-				"domutils": "1.5.1",
-				"nth-check": "~1.0.1"
-			}
-		},
-		"css-what": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
-		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -266,37 +227,6 @@
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
 			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
-		"dom-serializer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-			"requires": {
-				"domelementtype": "^1.3.0",
-				"entities": "^1.1.1"
-			}
-		},
-		"domelementtype": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-		},
-		"domhandler": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-			"requires": {
-				"domelementtype": "1"
-			}
-		},
-		"domutils": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-			"requires": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
-			}
-		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -315,11 +245,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-		},
-		"entities": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -476,19 +401,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-		},
-		"htmlparser2": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-			"requires": {
-				"domelementtype": "^1.3.1",
-				"domhandler": "^2.3.0",
-				"domutils": "^1.5.1",
-				"entities": "^1.1.1",
-				"inherits": "^2.0.1",
-				"readable-stream": "^3.1.1"
-			}
 		},
 		"http-errors": {
 			"version": "1.7.2",
@@ -682,14 +594,6 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
 			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
 		},
-		"nth-check": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-			"requires": {
-				"boolbase": "~1.0.0"
-			}
-		},
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -728,14 +632,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-		},
-		"parse5": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-			"requires": {
-				"@types/node": "*"
-			}
 		},
 		"parseurl": {
 			"version": "1.3.3",
@@ -781,11 +677,6 @@
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
 			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
 		},
-		"rarbg-api": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rarbg-api/-/rarbg-api-1.1.3.tgz",
-			"integrity": "sha512-9pkjwIDLOOOwB4U0AUw4tN9P4vV6tDizvHtkbu5KLpbJjLHneP3FMbHJeFT50yVy/9dTOaFtxg2zD3pGFgOaOg=="
-		},
 		"raw-body": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
@@ -795,16 +686,6 @@
 				"http-errors": "1.7.2",
 				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
-			}
-		},
-		"readable-stream": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-			"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
 			}
 		},
 		"request": {
@@ -985,9 +866,9 @@
 			}
 		},
 		"stremio-addon-sdk": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/stremio-addon-sdk/-/stremio-addon-sdk-1.1.4.tgz",
-			"integrity": "sha512-RpLImIJANHVxIoLhtA2jI8wuEJCERis6uAUaPdnx603jBqxGC6N4vRsDUSz8CT/wJMf6ioJM1yX32vubUomhsw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/stremio-addon-sdk/-/stremio-addon-sdk-1.4.0.tgz",
+			"integrity": "sha512-UMLqKUPvMzCrtOKRxOVfXD9IXJ0ZIBeWZNw0+JGsuPcs4X5V4Xm2Gtzxo9q+JHM6URL/kmI4Qmys23rLTF1aLQ==",
 			"requires": {
 				"chalk": "^2.4.2",
 				"cors": "^2.8.4",
@@ -997,7 +878,7 @@
 				"node-fetch": "^2.3.0",
 				"opn": "^5.4.0",
 				"router": "^1.3.3",
-				"stremio-addon-linter": "^1.6.1"
+				"stremio-addon-linter": "^1.7.0"
 			}
 		},
 		"string-width": {
@@ -1016,21 +897,6 @@
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
-				}
-			}
-		},
-		"string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"requires": {
-				"safe-buffer": "~5.2.0"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-					"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
 				}
 			}
 		},
@@ -1130,11 +996,6 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"utils-merge": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
 	},
 	"dependencies": {
 		"request": "^2.88.0",
-		"stremio-addon-sdk": "1.1.x"
+		"stremio-addon-sdk": "^1.4.0"
 	}
 }

--- a/serverless.js
+++ b/serverless.js
@@ -1,0 +1,11 @@
+const { getRouter } = require('stremio-addon-sdk')
+const addonInterface = require('./addon')
+
+const router = getRouter(addonInterface)
+
+module.exports = function(req, res) {
+	router(req, res, function() {
+		res.statusCode = 404
+		res.end()
+	})
+}

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,9 @@
+
+module.exports = {
+	capitalize: string => {
+		return string ? string.charAt(0).toUpperCase() + string.slice(1) : ''
+	},
+	serialize: obj => {
+		return Object.keys(obj).filter(k => !!obj[k]).map(k => k + '=' + encodeURIComponent(obj[k])).join('&')
+	}
+}


### PR DESCRIPTION
Hi! I noticed this add-on in Stremio and managed to find it on Github.

I noticed it was using the YTS api, and poked around in it to see if there is any way to improve it.

So here is a list of the improvements I made:
- catalogs are now ordered by seeds, to get top results
- added stream responses
- added caching to responses
- added `serverless.js` and `now.json` so it can be deployed to serverless Now.sh too
- added logo image to add-on

Check it out!

I also strongly recommend that you remove the Heroku deployment of this add-on and deploy it to Now.sh instead. The reason for this is that heroku stops apps when they reached some limit, Now.sh has no such limits and it also has a free CDN for caching, so it's by far a better choice.

Making a Now.sh account is easy and only requires an email. Deploying to Now.sh is very easy too.

To install the Now.sh client globally, do:
`npm i -g now`

Then login with your email:
`now login [my-email]` (change `[my-email]` to your email)

To deploy on Now.sh, just open your terminal in the project's folder, and type the command:
`now`

After you deploy, it's good to set a static alias to your deployment, so do something like:
`now alias stremio-yts.now.sh`

And then you can use the add-on from this URL:
`https://stremio-yts.now.sh/manifest.json`