### PR TITLE
Compatibility with PimpMyStremio

### DIFF
--- a/addon.js
+++ b/addon.js
@@ -1,12 +1,12 @@
 const { addonBuilder } = require('stremio-addon-sdk')
 const request = require('request')
-const NodeCache = require( "node-cache" );
+const myCache = require('./cache')
 
 const utils = require('./utils')
 const package = require('./package.json')
 
 const endpoint = 'https://yts.lt'
-const myCache = new NodeCache();
+
 const oneDay = 24 * 60 * 60 // in seconds
 
 const cache = {

--- a/cache.js
+++ b/cache.js
@@ -1,0 +1,14 @@
+
+const db = {}
+
+module.exports = {
+	set: (id, data, exp) => {
+		db[id] = data
+		setTimeout(() => {
+			delete db[id]
+		}, exp * 1000)
+	},
+	get: id => {
+		return db[id]
+	}
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
 		"start": "node server.js"
 	},
 	"dependencies": {
-		"node-cache": "5.1.0",
 		"request": "^2.88.2",
 		"stremio-addon-sdk": "^1.6.2"
 	}


### PR DESCRIPTION
I noticed your PR at PimpMyStremio: https://github.com/sungshon/PimpMyStremio/pull/76

This PR i made fixes compatibility with PimpMyStremio by removing the `node-cache` module, and replacing it with very simple logic that does exactly the same thing.

The addon will continue to work normally without PimpMyStremio too, but also work with PimpMyStremio.. so the PimpMyStremio PR for your addons can also be merged after this.